### PR TITLE
Add Amazon AI review overview to blocklist.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,31 @@
 
 Block AI adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html).
 
-## [0.0.1 Pre-release]
+## v0.0.2 Pre-release
+
+This version will be released following approval from [AMO](https://addons.mozilla.org/en-US/firefox/).
 
 ### Added
 
-- Blocks Google Search's AI Overview with CSS.
-- Blocks DuckDuckGo's AI assist with CSS.
-- Hides link to Duck.ai on <https://duckduckgo.com/>
-- Popup to show extension status.
-- Build pipeline for Firefox.
-- Firefox linting.
+#### Amazon
+
+* Hides AI overview of user reviews. Thank you to [TehhX](https://github.com/TehhX) who contributed this feature!
+
+## v0.0.1
+
+### Added
+
+#### Google
+
+* Hides Google Search's AI Overview.
+
+#### DuckDuckGo
+
+* Hides AI assist.
+* Hides link to Duck.ai on <https://duckduckgo.com/>
+
+#### Extension
+
+* Popup to show extension status.
+* Build pipeline for Firefox.
+* Firefox linting.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Block AI puts you in control, letting you decide when AI helps and when it gets 
 * DuckDuckGo
   * Blocks AI Assist.
   * Hides links to Duck.ai on the homepage.
+* Amazon
+  * Hides AI overview of user reviews.
 
 ## Build Instructions
 

--- a/common/amazonReviews.css
+++ b/common/amazonReviews.css
@@ -1,0 +1,2 @@
+/* Hide Amazon AI review overview */
+[cel_widget_id="cr-product-insights_customer-reviews-product-insights_0"] {display:none !important;}

--- a/common/amazonReviews.css
+++ b/common/amazonReviews.css
@@ -1,2 +1,2 @@
-/* Hide Amazon AI review overview */
+/* Hides "Customers say..." widget that appears at the top of customer reviews.*/
 [cel_widget_id="cr-product-insights_customer-reviews-product-insights_0"] {display:none !important;}

--- a/common/manifest.common.json
+++ b/common/manifest.common.json
@@ -406,6 +406,15 @@
                 "duckduckgoSearch.css"
             ],
             "run_at": "document_end"
+        },
+        {
+            "matches": [
+                "https://amazon.com/*",
+                "https://amazon.ca/*"
+            ],
+            "css": [
+                "amazonReviews.css"
+            ]
         }
     ],
     "action": {

--- a/common/manifest.common.json
+++ b/common/manifest.common.json
@@ -408,9 +408,32 @@
             "run_at": "document_end"
         },
         {
+            // Source: https://www.amazon.com/customer-preferences/country
             "matches": [
-                "https://www.amazon.com/*",
-                "https://www.amazon.ca/*"
+                "https://www.amazon.com.au/*", // Australia 
+                "https://www.amazon.com.be/*", // Belgium (Belgique)
+                "https://www.amazon.com.br/*", // Brazil (Brasil)
+                "https://www.amazon.ca/*", // Canada
+                "https://www.amazon.cn/*", // China (中国)
+                "https://www.amazon.eg/*", // Egypt (مصر) 
+                "https://www.amazon.fr/*", // France
+                "https://www.amazon.de/*", // Germany (Deutschland)
+                "https://www.amazon.in/*", // India
+                "https://www.amazon.ie/*", // Ireland
+                "https://www.amazon.it/*", // Italy (Italia)
+                "https://www.amazon.co.jp/*", // Japan (日本)
+                "https://www.amazon.com.mx/*", // Mexico (México)
+                "https://www.amazon.nl/*", // Netherlands (Nederland)
+                "https://www.amazon.pl/*", // Poland (Polska)
+                "https://www.amazon.sa/*", // Saudi Arabia (المملكة العربية السعودية)
+                "https://www.amazon.sg/*", // Singapore
+                "https://www.amazon.co.za/*", // South Africa
+                "https://www.amazon.es/*", // Spain (España)
+                "https://www.amazon.se/*", // Sweden (Sverige)
+                "https://www.amazon.com.tr/", // Turkey (Türkiye)
+                "https://www.amazon.ae/", // United Arab Emirates
+                "https://www.amazon.co.uk/", // United Kingdom
+                "https://www.amazon.com/*" // United States
             ],
             "css": [
                 "amazonReviews.css"

--- a/common/manifest.common.json
+++ b/common/manifest.common.json
@@ -409,12 +409,13 @@
         },
         {
             "matches": [
-                "https://amazon.com/*",
-                "https://amazon.ca/*"
+                "https://www.amazon.com/*",
+                "https://www.amazon.ca/*"
             ],
             "css": [
                 "amazonReviews.css"
-            ]
+            ],
+            "run_at": "document_end"
         }
     ],
     "action": {


### PR DESCRIPTION
* AI overviews removed via amazonReviews.css and edits to manifest.common.json
* Added new feature remark to README.md
* Tested as working on Mozilla Firefox 139.0 (64-bit) on Ubuntu Linux 24.04.2 LTS x86_64